### PR TITLE
Improve README layout and fix typo (Foundaation -> Foundation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,73 @@
 <h2 align="center">
-  Send and Receive with Meowcoin's web wallet.
+  Send and Receive with Meowcoin's web wallet.
 </h2>
 
-
 ---
-
 <br>
 
-<img align="left" src="assets/276_paperwallet_324x324.png" width="150">
-
+<table>
+<tr>
+<td width="160" valign="top">
+  <img src="assets/276_paperwallet_324x324.png" width="150" >
+</td>
+<td valign="top">
 
 ## Be your own Bank
+Meowcoin-Web-Wallet is a completely <a href="https://www.bitcoin.com/get-started/custodial-non-custodial-bitcoin-wallets/">non-custodial</a>, client-side system, giving you absolute control over your funds, data, bandwidth and privacy... all of which are essential to easily-attainable <b>self-sovereignty</b>.
 
-Meowcoin-Web-Wallet is a completely [non-custodial](https://www.bitcoin.com/get-started/custodial-non-custodial-bitcoin-wallets/), client-side system, giving you absolute control over your funds, data, bandwidth and privacy... all of which are essential to easily-attainable **self-sovereignty**.
-
-<br>
+</td>
+</tr>
+</table>
 
 ---
-
 <br>
 
-<img align="left" src="assets/276_paperwallet_324x324.png" width="150">
+<table>
+<tr>
+<td width="160" valign="top">
+  <img src="assets/276_paperwallet_324x324.png" width="150">
+</td>
+<td valign="top">
 
 ## Universal and Portable
+Meowcoin-Web-Wallet is completely universal and portable, at both a user-experience level & protocol-level, It is interopable with much of the functionality within MEWC, while also being portable enough to run on almost <b>any device in the world</b>.
 
-Meowcoin-Web-Wallet is completely universal and portable, at both a user-experience level & protocol-level, It is interopable with much of the functionality within MEWC, while also being portable enough to run on almost **any device in the world**.
-
-<br>
+</td>
+</tr>
+</table>
 
 ---
-
 <br>
 
-<img align="left" src="assets/276_paperwallet_324x324.png" width="150">
+<table>
+<tr>
+<td width="160" valign="top">
+  <img src="assets/276_paperwallet_324x324.png" width="150" >
+</td>
+<td valign="top">
 
 ## Don't trust, Verify!
+Meowcoin-Web-Wallet is completely free, open-source software (<a href="https://en.wikipedia.org/wiki/Free_and_open-source_software">FOSS</a>), with absolute transparency in security, features, down to every letter of code.
 
-Meowcoin-Web-Wallet is completely free, open-source software ([FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software)), with absolute transparency in security, features, down to every letter of code.
-
-<br>
+</td>
+</tr>
+</table>
 
 ---
-
 <br>
 
-<img align="left" src="assets/276_paperwallet_324x324.png" width="150">
+<table>
+<tr>
+<td width="160" valign="top">
+  <img src="assets/276_paperwallet_324x324.png" width="150" >
+</td>
+<td valign="top">
 
 ## By the Community, for the Community
+Meowcoin-Web-Wallet is built by <a href="https://github.com/Meowcoin-Foundation">MEWC Foundation</a> for the MEWC community to enjoy.
 
-Meowcoin-Web-Wallet is built by [MEWC Foundaation](https://github.com/Meowcoin-Foundation) for the MEWC community to enjoy.
+The mission of MEWC Foundation is to accelerate the adoption & growth of MEWC as a currency, using awesomeness. Join the <a href="https://discord.com/invite/meowcoin">MEWC Foundation Discord</a> to meet us!
 
-The mission of MEWC Foundation is to accelerate the adoption & growth of MEWC as a currency, using awesomeness. Join the [MEWC Foundation Discord](https://discord.com/invite/meowcoin) to meet us!
-
+</td>
+</tr>
+</table>


### PR DESCRIPTION
## Abstract

Currently there is a horizontal line that cuts into the images on the left because GitHub's formatting automatically adds a horizontal line after each h2 heading which does not wrap over elements.,an easy way to fix this is and keep the h2 is to wrap everything in a table. There is also a typo with the word foundation in the README.
<img width="1116" height="274" alt="image" src="https://github.com/user-attachments/assets/3d139665-751f-45a3-8155-621982d76b5f" />




---

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded MEWC: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
This PR addresses the typo and the layout of the README.

## What features or improvements were added?
Improves the layout of the README by using a table approach making everything look more uniform and also corrects the typo. 

## How does this benefit users?
Not directly,but makes the repo more presentable.

